### PR TITLE
add in animations and make the keyboard functional

### DIFF
--- a/app/src/main/java/com/avtarkhalsa/lvexample/activities/MainActivity.java
+++ b/app/src/main/java/com/avtarkhalsa/lvexample/activities/MainActivity.java
@@ -1,14 +1,21 @@
 package com.avtarkhalsa.lvexample.activities;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.avtarkhalsa.lvexample.LVExampleApplication;
@@ -40,6 +47,7 @@ public class MainActivity extends AppCompatActivity {
     Button nextButton;
     private Question currentQuestion;
 
+    private String invalidInputText = "Invalid Input";
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -95,14 +103,33 @@ public class MainActivity extends AppCompatActivity {
             //this is the code to run any time we get a new question
             //if we were using RetroLambda we would want to use a method reference instead
             questionView.bindToQuestion(question);
-            questionView.attemptToSetInputAsFocus();
+            EditText currentInput = questionView.getCurrentInput();
+            InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+            if(currentInput != null){
+                imm.showSoftInput(currentInput, InputMethodManager.SHOW_IMPLICIT);
+                currentInput.requestFocus();
+                currentInput.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+                    @Override
+                    public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                        if (actionId == EditorInfo.IME_ACTION_NEXT){
+                            Log.v("avtar-logger", "got a next event");
+                            nextClicked(nextButton);
+                            return true;
+                        }else{
+                            return false;
+                        }
+                    }
+                });
+            }else{
+                imm.hideSoftInputFromWindow(mainCoordinator.getWindowToken(), 0);
+            }
             currentQuestion = question;
         }
 
         @Override
         public void onError(Throwable e) {
             if(e instanceof QuestionManager.BadResponseException){
-                Toast.makeText(MainActivity.this, "Invalid Input", Toast.LENGTH_SHORT).show();
+                Toast.makeText(MainActivity.this, invalidInputText, Toast.LENGTH_SHORT).show();
             }
         }
 

--- a/app/src/main/java/com/avtarkhalsa/lvexample/managers/QuestionManager.java
+++ b/app/src/main/java/com/avtarkhalsa/lvexample/managers/QuestionManager.java
@@ -10,7 +10,7 @@ import io.reactivex.Maybe;
  * Created by avtarkhalsa on 12/25/16.
  */
 public interface QuestionManager {
-    public static class BadResponseException extends Exception{};
+    class BadResponseException extends Exception{};
 
     Maybe<Question> loadFirstQuestion();
 
@@ -19,6 +19,4 @@ public interface QuestionManager {
     Maybe<Question> setNumberResponseForQuestion(Double response, Question question);
 
     Maybe<Question> setChoicesResponseForQuestion(List<Integer> choice_indicies, Question question);
-
-    Question loadCompletedQuestionWithId(int question_id);
 }

--- a/app/src/main/java/com/avtarkhalsa/lvexample/managers/QuestionManagerImpl.java
+++ b/app/src/main/java/com/avtarkhalsa/lvexample/managers/QuestionManagerImpl.java
@@ -87,11 +87,6 @@ public class QuestionManagerImpl implements QuestionManager {
         return loadNextQuestion(question);
     }
 
-    @Override
-    public Question loadCompletedQuestionWithId(int question_id){
-        return completedQuestionsLookup.get(question_id);
-    }
-
     private Maybe<Question> loadNextQuestion(Question q){
         completedQuestionsLookup.put(q.getId(), q);
         final int new_id = q.getId()+1;

--- a/app/src/main/java/com/avtarkhalsa/lvexample/views/QuestionView.java
+++ b/app/src/main/java/com/avtarkhalsa/lvexample/views/QuestionView.java
@@ -5,13 +5,15 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
+import android.widget.TextSwitcher;
 import android.widget.TextView;
+import android.widget.ViewSwitcher;
 
 import com.avtarkhalsa.lvexample.R;
 import com.avtarkhalsa.lvexample.models.QuestionType;
@@ -34,7 +36,7 @@ public class QuestionView extends LinearLayout {
     }
 
     @BindView(R.id.question_label)
-    TextView question_label;
+    TextSwitcher question_label;
 
     @BindView(R.id.question_welcome)
     TextView welcome_label;
@@ -58,19 +60,8 @@ public class QuestionView extends LinearLayout {
         init();
     }
 
-    public void attemptToSetInputAsFocus(){
-        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-        if(textualInput.getVisibility() == View.VISIBLE){
-            imm.showSoftInput(textualInput, InputMethodManager.SHOW_IMPLICIT);
-        } else if (numericalInput.getVisibility() == View.VISIBLE){
-            imm.showSoftInput(numericalInput, InputMethodManager.SHOW_IMPLICIT);
-        }else{
-            imm.hideSoftInputFromWindow(this.getWindowToken(), 0);
-        }
-    }
-
-
     public void bindToQuestion(ViewModel vm){
+        //lets animate the question transition
         question_label.setText(vm.getLabel());
         hideAllInputs();
         clearAllInputs();
@@ -94,6 +85,16 @@ public class QuestionView extends LinearLayout {
         if(vm.getWelcome() != null){
             welcome_label.setVisibility(View.VISIBLE);
             welcome_label.setText(vm.getWelcome());
+        }
+    }
+
+    public EditText getCurrentInput(){
+        if(textualInput.getVisibility() == View.VISIBLE){
+            return textualInput;
+        }else if (numericalInput.getVisibility() == View.VISIBLE) {
+            return numericalInput;
+        }else{
+            return null;
         }
     }
 
@@ -135,6 +136,15 @@ public class QuestionView extends LinearLayout {
         inflate(getContext(), R.layout.question_view_layout, this);
         ButterKnife.bind(this);
         multiSelectInput.setLayoutManager(new LinearLayoutManager(getContext()));
+        question_label.setFactory(new ViewSwitcher.ViewFactory() {
+            public View makeView() {
+                return new TextView(getContext());
+            }
+        });
+        Animation in = AnimationUtils.loadAnimation(getContext(), android.R.anim.slide_in_left);
+        Animation out = AnimationUtils.loadAnimation(getContext(), android.R.anim.slide_out_right);
+        question_label.setInAnimation(in);
+        question_label.setOutAnimation(out);
     }
 
     private void populateSingleSelect(ViewModel vm){
@@ -166,6 +176,4 @@ public class QuestionView extends LinearLayout {
         multiSelectInput.setAdapter(null);
         currentMultiSelectAdapter = null;
     }
-
-
 }

--- a/app/src/main/res/layout/question_view_layout.xml
+++ b/app/src/main/res/layout/question_view_layout.xml
@@ -8,7 +8,7 @@
         android:layout_height="wrap_content"
         android:text="Hi John! Let’s talk about..."
         />
-    <TextView
+    <TextSwitcher
         android:id="@+id/question_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -19,11 +19,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/numerical_input"
+        android:imeOptions="actionNext"
         android:inputType="numberDecimal"/>
     <EditText
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/textual_input"
+        android:imeOptions="actionNext"
         android:inputType="text"/>
     <RadioGroup
         android:layout_width="match_parent"


### PR DESCRIPTION
MainActivity.java:  Move managing the keyboard out of the view and into the activity. The activity now requests the current EditText from the View and manages the keyboard depending on if its valid or not. We also can use this to catch taps on the "Next" key from the keyboard

QuestionManager.java: Get rid of unused methods and extra "public static"

QuestionManagerImpl.java: Remove unused method

QuestionView.java: Switch to textswitcher so we can animate in and out. Also replace attemptToSetInputAsFocus() with getCurrentInput(). This moves the keyboard management out of the view and into the activity. 

question_view_layout.xml: switch textview to TextSwitcher and make the keyboard action button the "next" icon 